### PR TITLE
check etcd operator status as well

### DIFF
--- a/api/argo-templates/ncn/worker.drain.yaml
+++ b/api/argo-templates/ncn/worker.drain.yaml
@@ -46,6 +46,12 @@ tasks:
           value: "{{ `{{inputs.parameters.dryRun}}` }}"
         - name: scriptContent
           value: |
+            while [[ "$(kubectl get po -A -l 'app=cray-etcd-operator-etcd-operator-etcd-operator' | grep -v "Running"| wc -l)" != "1" ]]; do
+                echo "Etcd operator is not in running state, wait for 5s ..."
+                kubectl get po -A -l 'app=cray-etcd-operator-etcd-operator-etcd-operator' | grep -v "Running"
+                sleep 5
+            done
+
             export GOSS_BASE=/opt/cray/tests/install/ncn
             GOSS_ARG="--vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate \
               --retry-timeout 1h \

--- a/api/argo-templates/ncn/worker.rebuild.yaml
+++ b/api/argo-templates/ncn/worker.rebuild.yaml
@@ -71,14 +71,13 @@ spec:
             {{- range $index,$value := .TargetNcns }}
             - {{$value -}}
             {{- end }}
-      # avoid using master node to run workflow jobs as soon as 
-      # we have worker nodes available
+      # try to use master nodes as much as possible
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 50
           preference:
             matchExpressions:
             - key: node-role.kubernetes.io/master
-              operator: DoesNotExist
+              operator: Exists
   entrypoint: main
   templates:
     - name: main


### PR DESCRIPTION
## Summary and Scope

- during multiple worker rebuild, we broke etcd cluster. the problem is that etcd operator was down and it didn't update CRD status and our check verifies CRD status which is not accurate. this PR add an additional check that make sure etcd operator is running
- we found that argo jobs on workers might be slow when it is put onto a freshly rebuilt worker. this is because all other pods are also starting on the worker. it would be better to use master nodes so we can be a lot faster

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5596](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5596)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `fanta`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

