### PR TITLE
CASM-3531: Add IUF product manifest schema

### DIFF
--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -71,25 +71,6 @@ properties:
       A description of the product.
     type: string
 
-  # ===========================================================================
-  # ================= Question for review session with teams ==================
-  # ===========================================================================
-  #
-  # Come back to this question at the end.
-  #
-  # This file is static and must be constructed at the product release
-  # distribution build time. Do any products require dynamic construction of
-  # this file?
-  #
-  # ===========================================================================
-
-  # ===========================================================================
-  # ================= Question for review session with teams ==================
-  # ===========================================================================
-  #
-  # Can teams use SemVer for their product versions?
-  #
-  # ===========================================================================
   version:
     description: >
       The version of the product. If not specified, the IUF will look for a
@@ -115,23 +96,6 @@ properties:
     # If we can enforce that every product uses SemVer, then we can use the
     # following official regex from the FAQ on semver.org.
     # pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
-
-
-  # ===========================================================================
-  # ================= Question for review session with teams ==================
-  # ===========================================================================
-  #
-  # We are not providing a way to declare dependencies for the initial release
-  # of the IUF in Alice. Do any product teams have examples of product install
-  # dependencies, particularly in the install stages responsible for uploading
-  # content, deploying services?
-  #
-  # Don: CSM-diags is dependent on CPE. This is a functional dependency?
-  # James: COS dependencies are at image build time (operational)
-  # Sarah: SDU has an operational dependency
-  #
-  # ===========================================================================
-
 
   content:
     type: object
@@ -207,27 +171,6 @@ properties:
                 will be uploaded to the "charts" Helm chart repository in Nexus.
               type: string
 
-      # =======================================================================
-      # =============== Question for review session with teams ================
-      # =======================================================================
-      #
-      # Will Loftsman manifests need a way to declare dependencies on other
-      # Loftsman manifests, either within a single product or across products?
-      #
-      # We plan to manifestgen all loftsman manifests by default. Is that a problem
-      # for any product teams? We can provide an option to disable it.
-      #
-      # SMA would pull customizations at run-time and modify it without pushing
-      # it back up and then use it to control size of something in S3.
-      #
-      # Do any products provide Loftsman manifests that they don't want to
-      # deploy as part of the product_deploy stage? E.g. WLM?
-      #
-      # Slurm has an operator that depends on some CSM multitenancy stuff in
-      # CSM 1.3 so you don't want to deploy unless on CSM 1.3, so it's been
-      # separated out.
-      #
-      # =======================================================================
       loftsman:
         description: >
           An array of Loftsman manifest files or directories containing Lofstman
@@ -274,16 +217,6 @@ properties:
               type: boolean
               default: true
 
-      # =======================================================================
-      # =============== Question for review session with teams ================
-      # =======================================================================
-      #
-      # Do any products currently have more than one "nexus-repositories.yaml"
-      # or "nexus-blobstores.yaml" file in their product stream?
-      #
-      # Question from Erik: how do we handle SLE with its multiple tar files?
-      #
-      # =======================================================================
       nexus_blob_stores:
         description: >
           The Nexus blob stores that should be defined for this product.
@@ -354,13 +287,6 @@ properties:
               - raw
               - yum
 
-      # =======================================================================
-      # =============== Question for review session with teams ================
-      # =======================================================================
-      #
-      # Do any products need to provide more than one VCS repo?
-      #
-      # =======================================================================
       vcs:
         default: {}
         description: >
@@ -455,15 +381,6 @@ properties:
                     The name of the initrd file for the image.
                   type: string
 
-      # =======================================================================
-      # =============== Question for review session with teams ================
-      # =======================================================================
-      #
-      # Analytics and CPE do this today. Do any other products do this?
-      #
-      # Slingshot fabric manager does this for switch firmware with FAS.
-      #
-      # =======================================================================
       s3:
         description: >
           Information about additional artifacts that should be uploaded to S3

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -194,15 +194,15 @@ properties:
           manifest files provided by the product.
 
 
-          (TODO) What do we do with these files? Should they get uploaded
-          somewhere on the system (e.g. a Nexus repository of some type or a
-          bucket in S3)? Should they be processed with manifestgen (perhaps
-          optionally)? Should some be flagged as manifests which should be
-          deployed by the deploy\_product/deploy\_manifests stage while others
-          can be skipped? David Gloe has a question about that.
+          # TODO: Discuss with Atif where these manifests should be stored.
+          # Also decide whether we store pre- or post-manifestgen versions.
+          # This ties into the discussion about where we store hooks and any
+          # artifacts needed for any future product install/upgrade/uninstall
+          # operations.
 
-          (TODO) Is there a need to specify dependencies here? Either within a
-          single product's Loftsman manifests or between products?
+          # TODO: Is there a need to specify dependencies here? Either within a
+          # single product's Loftsman manifests or between products?
+          # Discuss with Atif how dependencies are declared.
         type: array
         default:
         - path: manifests
@@ -215,32 +215,60 @@ properties:
           properties:
             path:
               description: >
-                The path to a loftsman manifest file, relative to the top level
+                The path to a loftsman manifest file or directory, relative to the top level
                 of the release distribution directory.
               type: string
+
+            # TODO: Consider whether dependencies between loftsman manifests are needed here
+            # Jason suggests that perhaps they belong in a separate section.
+            # Example schema below
+            dependencies:
+              type: array
+              items:
+                type: object
+                properties:
+                  product:
+                    type: string
+                    description: name of product
+                  manifest_name:
+                    type: string
+                    description: name of manifest provided by product
+            # End of example
+
             use_manifestgen:
               description: >
                 Whether manifestgen needs to be called against the manifest(s).
+
+                manifestgen takes the customizations.yaml file and applies the customizations
+                to the Loftsman manifest file. Customizations to the manifest themselves or to
+                to the values that are passed through to the helm charts.
               type: boolean
               # TODO: Is it more common that products require this or do not require it?
-              # Is it harmless if they do not require it?
+              # Is it harmless if they do not require it? Should be harmless.
               default: true
             deploy:
               description: >
                 Whether this loftsman manifest should be deployed as part of the
                 deploy_manifests stage of the IUF.
+
+                # TODO: Reach out to David Gloe to ask for specifics on the WLM use case.
+                # Why would we ever not want to deploy manifests during the deploy_manifests stage?
               type: boolean
               default: true
 
       blobstores_definition:
         description: >
           The path to a YAML file that defines the blobstores that should be
-          created for this product. The YAML file should consist of a series 
+          created for this product. The YAML file should consist of a series
           documents, each of which defines a blobstore.
 
           The schema of each document is unchanged from the Papaya recipe
           release.
         type: string
+        # TODO: Do any products define more than one blobstore?
+        # It is possible to do this with a single nexus-blobstores.yaml file
+        # by specifying multiple documents. Check if any products define multiple
+        # blobstores in multiple files (possible SLE)
         default: nexus-blobstores.yaml
 
       repositories_definition:
@@ -251,6 +279,10 @@ properties:
 
           The schema of each document is unchanged from the Papaya recipe
           release.
+
+          # TODO: Define behavior when repositories defined here already exist in Nexus.
+          # Investigate why Slurm had to delete the old repos. Was it a way to ensure
+          # the type is modified.
         type: string
         default: nexus-repositories.yaml
 
@@ -301,7 +333,7 @@ properties:
 
       # TODO: Similarly we could use a "blobstores" property instead of using
       # the "blobstores_definition" property.
-      
+
 
       vcs:
         description: TODO

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -81,6 +81,57 @@ properties:
     # This regex is the official one from the FAQ on semver.org
     pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 
+
+  # ===========================================================================
+  # TODO: Another example of a way to do dependencies where each product can
+  # declare what it provides vs. requires (similar to RPM).
+  #
+  # Deferred in Alice timeframe
+  # ===========================================================================
+  provides:
+    type: array
+    items:
+      type: string
+      description: TBD. Some sort of string describing what it provides.
+
+  requires:
+    type: array
+    items:
+      type: string
+      description: TBD. Some sort of string describing what it requires.
+  # ===========================================================================
+
+  # ===========================================================================
+  # TODO: One way of specifying dependencies between products would be to have
+  # dependencies at the top level here.
+  #
+  # A lot of this is somewhat handled at the HPC CSM Software Recipe manifest
+  # level because this is a set of software that has been validated together.
+  # This doesn't handle one-off install dependency checking.
+  dependencies:
+    description: >
+      The other products on which this product depends. This would be overall
+      dependencies one product has on another, affecting all (?) stages/operations
+      of the product.
+
+      # TODO: Ask product teams about existing dependencies. Atif has not seen
+      # any of these so far. Especially in upload_content. Dean cautions against
+      # doing this at too high of a level because teams will get overly cautious
+      # here and specify dependencies that aren't really needed.
+    type: list
+    items:
+      type: object
+      required:
+      - product_name
+      properties:
+        product_name:
+          description: Name of product on which this one depends.
+          type: string
+        product_version:
+          description: Version of product on which this one depends.
+          type: string
+  # ===========================================================================
+
   content:
     # TODO: Consider whether defaults can/should be specified at this level (in case content property is omitted)
     default:
@@ -180,6 +231,10 @@ properties:
             # TODO: Investigate how loftsman knows which Helm repository to use from Nexus
             # Di says that loftsman needs local copies of the charts instead of going to Nexus.
             # We confirmed that loftsman uses local copies of charts (e.g. COS). File CASMTRIAGE for loftsman support of remote repos.
+            #
+            # Rob found that loftsman command can use remote chart repos.
+            # Unclear how this works. `--charts-repo` exists, but it is
+            # deprecated in favor of `spec.sources.charts` in the manifests.
             repository_name:
               description: >
                 The name of the repository to which the Helm charts should be
@@ -199,6 +254,8 @@ properties:
           # This ties into the discussion about where we store hooks and any
           # artifacts needed for any future product install/upgrade/uninstall
           # operations.
+          # Decision: they will be stored in S3 (pre- and post-manifestgen
+          # versions)
 
           # TODO: Is there a need to specify dependencies here? Either within a
           # single product's Loftsman manifests or between products?
@@ -208,6 +265,11 @@ properties:
         - path: manifests
           deploy: true
           manifestgen: true
+
+          # TODO: Example of dependencies
+          # dependencies:
+          # - product: cos
+          #   manifest_path: manifests
         items:
           type: object
           required:
@@ -221,6 +283,10 @@ properties:
 
             # TODO: Consider whether dependencies between loftsman manifests are needed here
             # Jason suggests that perhaps they belong in a separate section.
+            #
+            # Decision: let's not do this for Alice. We can ask product teams
+            # about whether this is required.
+            #
             # Example schema below
             dependencies:
               type: array
@@ -245,6 +311,13 @@ properties:
               type: boolean
               # TODO: Is it more common that products require this or do not require it?
               # Is it harmless if they do not require it? Should be harmless.
+              #
+              # Atif want to move away from specifying all config values in
+              # customizations.yaml and move towards having these be specified
+              # by the admin either in a file or in a wizard guiding them
+              # through answering required questions as part of starting an IUF
+              # session. We will keep this unchanged for Alice to minimize
+              # impact to product teams and improve in the future.
               default: true
             deploy:
               description: >
@@ -253,6 +326,9 @@ properties:
 
                 # TODO: Reach out to David Gloe to ask for specifics on the WLM use case.
                 # Why would we ever not want to deploy manifests during the deploy_manifests stage?
+                # Atif suggests asking this question at the next meeting with
+                # product teams. Atif hasn't seen any examples where this would
+                # be required. Assume they all need to be deployed.
               type: boolean
               default: true
 
@@ -283,6 +359,11 @@ properties:
           # TODO: Define behavior when repositories defined here already exist in Nexus.
           # Investigate why Slurm had to delete the old repos. Was it a way to ensure
           # the type is modified.
+          #
+          # Atif suggests that we must always back up old content if we would
+          # overwrite it. 
+          #
+          # This needs to be discussed further as part of the IUF spec.
         type: string
         default: nexus-repositories.yaml
 
@@ -295,6 +376,7 @@ properties:
           type: object
           required:
           - path
+          - repository_name
           properties:
             path:
               description: >
@@ -313,6 +395,10 @@ properties:
                 # nexus-repositories.yaml, and their install.sh files using sed.
                 # It would probably be simplest for Alice to just allow products
                 # to keep managing those substitutions themselves.
+                #
+                # Decision: For Alice, we won't worry about this. Post-Alice, we
+                # could offer release-generation libraries to simplify across
+                # products.
 
       # =======================================================================
       # An alternative way to define Nexus repos under a repositories property
@@ -355,6 +441,8 @@ properties:
       # =======================================================================
 
       vcs:
+        # TODO: Ask product teams if any product provides more than one VCS
+        # repo.
         default: {}
         description: >
           Information about the VCS repository to be created for this product.
@@ -377,9 +465,59 @@ properties:
               respectively. It is recommended not to change this value unless it is
               required to do so.
             type: string
+          # The following property is one we want to allow the admin to
+          # override. For Alice, let's not add this property. Let's just worry
+          # about the content upload.
+          site_branch:
+            type: string
+            description: >
+              The branch name to use as the branch for site customizations.
+              cpe-integration-22.09
 
       ims:
-        description: TODO
+        description: >
+          Information about the IMS images and/or recipes to be uploaded into
+          IMS for this product.
+        type: object
+        properties:
+          recipes:
+            type: array
+            items:
+              type: object
+              required:
+              - path
+              properties:
+                path:
+                  description: >
+                    The path, relative to the top level of the product release
+                    distribution, to the recipe as a gzipped tar file.
+
+                    # TODO: Still trying to understand the structure here and
+                    # how products will be able to build and package recipes.
+                  type: string
+                name:
+                  description: >
+                    Name of the recipe. Or we could default to the name of the tar file.
+                  type: string
+          images:
+            type: array
+            items:
+              type: object
+              required:
+              - path
+              properties:
+                path:
+                  description: >
+                    The path, relative to the top level of the product release
+                    distribution, to the directory containing the image artifacts.
+
+                    # TODO: Still trying to understand the structure here and
+                    # how products will be able to build and package images.
+                  type: string
+                name:
+                  description: >
+                    The name of the image to create.
+                  type: string
 
       s3:
         description: TODO

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -427,7 +427,7 @@ properties:
                   description: >
                     The relative path to the directory containing the image
                     artifacts. The directory should contain a root filesystem
-                    image the squashfs format, a kernel file, and an initrd.
+                    image in the squashfs format, a kernel file, and an initrd.
 
                     An IMS image record will be created, the image artifacts
                     will be uploaded to the appropriate paths in S3, an IMS
@@ -441,6 +441,22 @@ properties:
                     default to the name of the directory containing the image
                     artifacts.
                   type: string
+                rootfs_file:
+                  description: >
+                    The name of the squashfs file defining the root filesystem for
+                    the image.
+                  type: string
+                  default: rootfs
+                kernel_file:
+                  description: >
+                    The name of the kernel file for the image.
+                  type: string
+                  default: kernel
+                initrd_file:
+                  description: >
+                    The name of the initrd file for the image.
+                  type: string
+                  default: initrd
 
       # =======================================================================
       # =============== Question for review session with teams ================

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -71,6 +71,25 @@ properties:
       A description of the product.
     type: string
 
+  # ===========================================================================
+  # ================= Question for review session with teams ==================
+  # ===========================================================================
+  #
+  # Come back to this question at the end.
+  #
+  # This file is static and must be constructed at the product release
+  # distribution build time. Do any products require dynamic construction of
+  # this file?
+  #
+  # ===========================================================================
+
+  # ===========================================================================
+  # ================= Question for review session with teams ==================
+  # ===========================================================================
+  #
+  # Can teams use SemVer for their product versions?
+  #
+  # ===========================================================================
   version:
     description: >
       The version of the product. If not specified, the IUF will look for a
@@ -191,10 +210,11 @@ properties:
       # Will Loftsman manifests need a way to declare dependencies on other
       # Loftsman manifests, either within a single product or across products?
       #
-      # Which teams use manifestgen, and which don't?
+      # We plan to manifestgen all loftsman manifests by default. Is that a problem
+      # for any product teams? We can provide an option to disable it.
       #
       # Do any products provide Loftsman manifests that they don't want to
-      # deploy as part of the product install and deployment? E.g. WLM?
+      # deploy as part of the product_deploy stage? E.g. WLM?
       #
       # =======================================================================
       loftsman:

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -358,6 +358,8 @@ properties:
               "PRODUCT_VERSION" is the version of the product.
             type: string
 
+      # TODO: Need to understand how products will build and package recipes and
+      # images for inclusion in their product release distribution files.
       ims:
         description: >
           Information about the IMS images and/or recipes to be uploaded into
@@ -373,15 +375,13 @@ properties:
               properties:
                 path:
                   description: >
-                    The path, relative to the top level of the product release
-                    distribution, to the recipe as a gzipped tar file.
-
-                    # TODO: Still trying to understand the structure here and
-                    # how products will be able to build and package recipes.
+                    The relative path to the recipe as a gzipped tar file.
                   type: string
                 name:
                   description: >
-                    Name of the recipe. Or we could default to the name of the tar file.
+                    The name of the recipe to be created in IMS. If omitted,
+                    this will default to the name of the tar file without the
+                    ".tar.gz" extension.
                   type: string
           images:
             type: array
@@ -392,15 +392,21 @@ properties:
               properties:
                 path:
                   description: >
-                    The path, relative to the top level of the product release
-                    distribution, to the directory containing the image artifacts.
+                    The relative path to the directory containing the image
+                    artifacts. The directory should contain a root filesystem
+                    image the squashfs format, a kernel file, and an initrd.
 
-                    # TODO: Still trying to understand the structure here and
-                    # how products will be able to build and package images.
+                    An IMS image record will be created, the image artifacts
+                    will be uploaded to the appropriate paths in S3, an IMS
+                    manifest that references those artifacts will be constructed
+                    and uploaded to S3, and the IMS image record will be updated
+                    with that manifest.
                   type: string
                 name:
                   description: >
-                    The name of the image to create.
+                    The name of the image to create. If omitted, this will
+                    default to the name of the directory containing the image
+                    artifacts.
                   type: string
 
       s3:

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -232,11 +232,76 @@ properties:
               type: boolean
               default: true
 
-      rpms:
-        description: TODO
+      blobstores_definition:
+        description: >
+          The path to a YAML file that defines the blobstores that should be
+          created for this product. The YAML file should consist of a series 
+          documents, each of which defines a blobstore.
 
+          The schema of each document is unchanged from the Papaya recipe
+          release.
+        type: string
+        default: nexus-blobstores.yaml
+
+      repositories_definition:
+        description: >
+          The path to a YAML file that defines the Nexus repositories that
+          should be create for this product. The YAML file should consist of a
+          series of documents, each of which defines a Nexus repository.
+
+          The schema of each document is unchanged from the Papaya recipe
+          release.
+        type: string
+        default: nexus-repositories.yaml
+
+      rpms:
+        description: >
+          An array of directories containing RPMs that should be uploaded to the
+          repositories defined by the "repositories_definition" property.
+        type: array
+        items:
+          type: object
+          required:
+          - path
+          properties:
+            path:
+              description: >
+                The path to a directory containing RPMs to upload to a package
+                repository in Nexus, relative to the top level of the release
+                distribution directory.
+              type: string
+            repository_name:
+              description: >
+                The name of the repository to which these RPMs should be uploaded.
+
+                # TODO: Should we support product name and version substitutions
+                # in this file at product install time? Currently, many products
+                # do this sort of variable substitution at packaging time in
+                # `release.sh` by templating their nexus-blobstores.yaml,
+                # nexus-repositories.yaml, and their install.sh files using sed.
+                # It would probably be simplest for Alice to just allow products
+                # to keep managing those substitutions themselves.
+
+      # TODO: A repositories key would be an alternative way to specify the
+      # Nexus repositories instead of having them defined in a separate file
+      # referenced by the value of the "repositories_definition" property.
+      # For example:
+      #
       repositories:
-        description: TODO
+        description: >
+          A list of repositories.
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              description: The name of the repo to create
+              type: string
+            # More properties defining the repo would go here.
+
+      # TODO: Similarly we could use a "blobstores" property instead of using
+      # the "blobstores_definition" property.
+      
 
       vcs:
         description: TODO

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -314,29 +314,69 @@ properties:
                 # It would probably be simplest for Alice to just allow products
                 # to keep managing those substitutions themselves.
 
-      # TODO: A repositories key would be an alternative way to specify the
-      # Nexus repositories instead of having them defined in a separate file
-      # referenced by the value of the "repositories_definition" property.
-      # For example:
-      #
+      # =======================================================================
+      # An alternative way to define Nexus repos under a repositories property
+      # instead of defining them in a separate file referenced by the value of
+      # the "repositories_definition" property.
+      # =======================================================================
       repositories:
         description: >
-          A list of repositories.
+          An array of package repositories.
         type: array
         items:
           type: object
+          required: name
           properties:
             name:
               description: The name of the repo to create
               type: string
             # More properties defining the repo would go here.
+      # =======================================================================
 
-      # TODO: Similarly we could use a "blobstores" property instead of using
-      # the "blobstores_definition" property.
-
+      # =======================================================================
+      # An alternative way to define Nexus blob stores under a blobstores
+      # property instead of defining them in a separate file referenced by the
+      # value of the "blobstores_definition" property.
+      # =======================================================================
+      blobstores:
+        description: >
+          An array of blobstores that should be created in Nexus for this
+          product.
+        type: array
+        items:
+          type: object
+          required:
+          - name
+          properties:
+            name:
+              description: The name of the blobstore to create
+              type: string
+            # More properties defining the blobstore would go here.
+      # =======================================================================
 
       vcs:
-        description: TODO
+        default: {}
+        description: >
+          Information about the VCS repository to be created for this product.
+        type: object
+        required:
+        - path
+        properties:
+          path:
+            description: >
+              The path, relative to the top level of the product release
+              distribution, to the directory containing the content to upload to
+              a repository in VCS.
+            type: string
+          import_branch:
+            description: >
+              The branch name to which the content in the given path should be
+              uploaded in VCS. If this is omitted, the default behavior is to upload
+              to a path of the form cray/${PRODUCT_NAME}/${PRODUCT_VERSION} where
+              PRODUCT_NAME and PRODUCT_VERSION are the name and version of the product,
+              respectively. It is recommended not to change this value unless it is
+              required to do so.
+            type: string
 
       ims:
         description: TODO

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -252,7 +252,7 @@ properties:
       # =======================================================================
       #
       # Do any products currently have more than one "nexus-repositories.yaml"
-      # file in their product stream?
+      # or "nexus-blobstores.yaml" file in their product stream?
       #
       # =======================================================================
       nexus_blob_stores:
@@ -288,8 +288,8 @@ properties:
               defines a Nexus repository.
 
               The schema of this file is unchanged from the Papaya recipe.
-          type: string
-          default: nexus-repositories.yaml
+            type: string
+            default: nexus-repositories.yaml
 
       rpms:
         description: >

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -409,5 +409,33 @@ properties:
                     artifacts.
                   type: string
 
+      # =======================================================================
+      # =============== Question for review session with teams ================
+      # =======================================================================
+      #
+      # Analytics and CPE do this today. Do any other products do this?
+      #
+      # =======================================================================
       s3:
-        description: TODO
+        description: >
+          Information about additional artifacts that should be uploaded to S3
+        type: array
+        items:
+          required:
+          - path
+          - bucket
+          - key
+          properties:
+            path:
+              description: >
+                The relative path to the file that should be uploaded to S3.
+              type: string
+            bucket:
+              description: >
+                The S3 bucket to which this file should be uploaded.
+              type: string
+            key:
+              description: >
+                The key of the object to be created in S3.
+          type: object
+

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -290,7 +290,7 @@ properties:
       rpms:
         description: >
           An array of directories containing RPMs that should be uploaded to the
-          repositories defined by the "repositories_definition" property.
+          repositories defined by the "nexus_repositories" property.
         type: array
         items:
           type: object
@@ -300,25 +300,26 @@ properties:
           properties:
             path:
               description: >
-                The path to a directory containing RPMs to upload to a package
-                repository in Nexus, relative to the top level of the release
-                distribution directory.
+                The relative path to a directory containing RPMs to upload to a
+                repository in Nexus. This directory may also contain yum
+                repository metadata files, and they will also be uploaded to
+                the repository in Nexus.
               type: string
             repository_name:
               description: >
-                The name of the repository to which these RPMs should be uploaded.
-
-                # TODO: Should we support product name and version substitutions
-                # in this file at product install time? Currently, many products
-                # do this sort of variable substitution at packaging time in
-                # `release.sh` by templating their nexus-blobstores.yaml,
-                # nexus-repositories.yaml, and their install.sh files using sed.
-                # It would probably be simplest for Alice to just allow products
-                # to keep managing those substitutions themselves.
-                #
-                # Decision: For Alice, we won't worry about this. Post-Alice, we
-                # could offer release-generation libraries to simplify across
-                # products.
+                The name of the repository to which these RPMs should be
+                uploaded. This repository should have been defined in the file
+                referenced by the "nexus_repositories" property.
+              type: string
+            repository_type:
+              description: >
+                The type of the Nexus repository to which the RPMs should be
+                uploaded.
+              type: string
+              default: raw
+              enum:
+              - raw
+              - yum
 
       vcs:
         # TODO: Ask product teams if any product provides more than one VCS

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -10,6 +10,8 @@ type: object
 required:
 - schema_version
 - name
+# TODO: Generally would like this throughout all objects as it provides more
+# guarantee of backwards compatibility of old manifests with newer schema.
 additionalProperties: false
 properties:
 
@@ -17,7 +19,7 @@ properties:
     description: >
       The version of the IUF product manifest schema used by this manifest. The
       version of the schema should be a SemVer-like version number with three
-      components, major.minor.patch. 
+      components, major.minor.patch.
 
       This version will be checked against the current schema version understood
       by the IUF.
@@ -41,6 +43,7 @@ properties:
         current version.
 
       - If the input version matches the current version, it is compatible.
+    # TODO: Atif want to see this with a range, e.g. ^1.0.0 or ~1.0.0
     default: '1.0.0'
     type: string
 
@@ -51,25 +54,46 @@ properties:
     type: string
     # TODO: Do we want to define a regular expression for allowed product names
     # pattern: regex in ECMA-262 regular expression dialect goes here
-  
+
+  # TODO: Do we want a long name in a description too?
+  description:
+    description: >
+      A longer name for the product. This is for humans to read and understand.
+      E.g. slingshot-host-software could say what SHS stands for.
+    type: string
+
   version:
     description: >
       The version of the product. The format of this version string must conform
       to the Semantic Versioning 2.0.0 Spec. The version numbers do not need to
       be assigned and incremented in accordance with the rules and requirements
       dictated by SemVer, however.
+
+      # TODO: Consider whether we want to fall back on the `.version` file that some products
+      # deliver in the release distribution tar file. E.g. Slurm provides one. We don't want
+      # to make the build process more complicated. Or provide a path to the version file. In
+      # this case, we could use a oneOf in the schema.
+
+      # TODO: Need to look at SLE, CPE, and other products to see if they can fit into SemVer
+      # Note that SemVer is pretty flexible (e.g. should be able to support SLE date strings).
+      # Product like CPE already have to conform to use cray-import-config/cf-gitea-import
     type: string
     # This regex is the official one from the FAQ on semver.org
     pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
-      
+
   content:
+    # TODO: Consider whether defaults can/should be specified at this level (in case content property is omitted)
+    default:
+      docker:
+      - path: docker
+        strip_leading_components: 0
     type: object
     description: >
       The content delivered by this product, including container images, RPMs,
       packages repositories, helm charts, loftsman manifests, VCS repositories,
       IMS images and recipes, and S3 artifacts.
 
-        
+
       Note that if the layout of the content is not specified in this manifest,
       the IUF will assume a default layout as described in the properties here.
 
@@ -80,9 +104,16 @@ properties:
           uploaded to the Docker image registry in Nexus at install/upgrade
           time.
 
+        default:
+        - path: "docker"
+        # TODO: do we want this as opposed to objects.
+        # - "docker"
+
         type: array
         items:
           type: object
+          required:
+          - path
           properties:
             path:
               description: |
@@ -96,7 +127,7 @@ properties:
                 the directory containing the image manifest.json file.
 
                 For example, if this path contains the following file structure
-                
+
                 arti.hpc.amslabs.hpecorp.net/
                 └── my-container:1.2.4
                     ├── 007c21b118030b56ce4c303c6ef668f6bdcf2e14f5e63f079b19e1d1883ac7a9
@@ -109,6 +140,11 @@ properties:
               type: string
 
             # TODO: Do we need the ability to strip components from the path?
+            # Maybe this needs a spike to see how product teams are storing their docker images.
+            # E.g. SAT puts them all under cray/ prefix. COS mixes that approach with using
+            # arti.hpc.../ prefix.
+            # Maybe we don't need to worry about this. Make the product mirror the naming in the nexus
+            # registry with their file structure.
             strip_leading_components:
               type: integer
               default: 0
@@ -116,4 +152,97 @@ properties:
                 How many leading components of the path should be stripped off when
                 uploading the image to Nexus.
 
-  
+      helm:
+        description: >
+          An array of directories containing helm charts that should be
+          uploaded to a Helm chart repository in Nexus at install/upgrade
+          time.
+        type: array
+        default:
+        - path: helm
+          repository_name: charts
+        # TODO: Consider simplifying this to just a list of strings like "docker" above
+        # - "helm"
+        items:
+          type: object
+          required:
+          - path
+          properties:
+            path:
+              description: >
+                The path, relative to the top level of the release distribution
+                directory, containing the helm charts to be uploaded to a Helm
+                chart repository in Nexus.
+              type: string
+
+            # TODO: We can probably simplify here for now. Everybody is using "charts".
+            # Putting charts in their own repository for each product is out of scope for IUF.
+            # TODO: Investigate how loftsman knows which Helm repository to use from Nexus
+            # Di says that loftsman needs local copies of the charts instead of going to Nexus.
+            # We confirmed that loftsman uses local copies of charts (e.g. COS). File CASMTRIAGE for loftsman support of remote repos.
+            repository_name:
+              description: >
+                The name of the repository to which the Helm charts should be
+                uploaded in Nexus.
+              type: string
+              default: charts
+
+
+      loftsman:
+        description: >
+          An array of Loftsman manifest files or directories containing Lofstman
+          manifest files provided by the product.
+
+
+          (TODO) What do we do with these files? Should they get uploaded
+          somewhere on the system (e.g. a Nexus repository of some type or a
+          bucket in S3)? Should they be processed with manifestgen (perhaps
+          optionally)? Should some be flagged as manifests which should be
+          deployed by the deploy\_product/deploy\_manifests stage while others
+          can be skipped? David Gloe has a question about that.
+
+          (TODO) Is there a need to specify dependencies here? Either within a
+          single product's Loftsman manifests or between products?
+        type: array
+        default:
+        - path: manifests
+          deploy: true
+          manifestgen: true
+        items:
+          type: object
+          required:
+          - path
+          properties:
+            path:
+              description: >
+                The path to a loftsman manifest file, relative to the top level
+                of the release distribution directory.
+              type: string
+            use_manifestgen:
+              description: >
+                Whether manifestgen needs to be called against the manifest(s).
+              type: boolean
+              # TODO: Is it more common that products require this or do not require it?
+              # Is it harmless if they do not require it?
+              default: true
+            deploy:
+              description: >
+                Whether this loftsman manifest should be deployed as part of the
+                deploy_manifests stage of the IUF.
+              type: boolean
+              default: true
+
+      rpms:
+        description: TODO
+
+      repositories:
+        description: TODO
+
+      vcs:
+        description: TODO
+
+      ims:
+        description: TODO
+
+      s3:
+        description: TODO

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -65,7 +65,6 @@ properties:
     # TODO: Consider a regular expression for allowed product names
     # pattern: <regex in ECMA-262 regular expression dialect goes here>
 
-  # TODO: Do we want a long name in a description too?
   description:
     description: >
       A description of the product.
@@ -112,6 +111,7 @@ properties:
       beneath "content", it means a path relative to the top level of the
       product release distribution file.
 
+    additionalProperties: false
     properties:
       docker:
         description: >
@@ -125,6 +125,7 @@ properties:
           type: object
           required:
           - path
+          additionalProperties: false
           properties:
             path:
               description: |
@@ -162,6 +163,7 @@ properties:
           type: object
           required:
           - path
+          additionalProperties: false
           properties:
             path:
               description: >
@@ -193,6 +195,7 @@ properties:
           type: object
           required:
           - path
+          additionalProperties: false
           properties:
             path:
               description: >
@@ -223,6 +226,7 @@ properties:
         type: object
         required:
         - yaml_path
+        additionalProperties: false
         properties:
           yaml_path:
             description: >
@@ -241,6 +245,7 @@ properties:
         type: object
         required:
         - yaml_path
+        additionalProperties: false
         properties:
           yaml_path:
             description: >
@@ -263,6 +268,7 @@ properties:
           required:
           - path
           - repository_name
+          additionalProperties: false
           properties:
             path:
               description: >
@@ -295,6 +301,7 @@ properties:
         type: object
         required:
         - path
+        additionalProperties: false
         properties:
           path:
             description: >
@@ -317,13 +324,12 @@ properties:
               "PRODUCT_VERSION" is the version of the product.
             type: string
 
-      # TODO: Need to understand how products will build and package recipes and
-      # images for inclusion in their product release distribution files.
       ims:
         description: >
           Information about the IMS images and/or recipes to be uploaded into
           IMS for this product.
         type: object
+        additionalProperties: false
         properties:
           recipes:
             type: array
@@ -331,6 +337,7 @@ properties:
               type: object
               required:
               - path
+              additionalProperties: false
               properties:
                 path:
                   description: >
@@ -348,6 +355,7 @@ properties:
               type: object
               required:
               - path
+              additionalProperties: false
               properties:
                 path:
                   description: >
@@ -386,10 +394,12 @@ properties:
           Information about additional artifacts that should be uploaded to S3
         type: array
         items:
+          type: object
           required:
           - path
           - bucket
           - key
+          additionalProperties: false
           properties:
             path:
               description: >
@@ -402,5 +412,4 @@ properties:
             key:
               description: >
                 The key of the object to be created in S3.
-          type: object
 

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -4,48 +4,49 @@ title: "Product Manifest for HPE CSM Install-Upgrade Framework (IUF)"
 description: >
   A manifest that defines the behavior of the IUF when it performs operations
   against this product.
-# This is the version of the schema itself
+# This is the version of the IUF manifest schema itself
 version: 0.1.0
 type: object
 required:
-- schema_version
+- iuf_version
 - name
 # TODO: Generally would like this throughout all objects as it provides more
 # guarantee of backwards compatibility of old manifests with newer schema.
+#
+# Using additionalProperties false helps ensure backwards compatibility of old
+# IUF manifest files with newer schema versions because old manifest files will
+# not be able to use additional properties which are then later added to the IUF
+# manifest schema.
 additionalProperties: false
 properties:
 
-  schema_version:
+  iuf_version:
     description: >
-      The version of the IUF product manifest schema used by this manifest. The
-      version of the schema should be a SemVer-like version number with three
-      components, major.minor.patch.
-
-      This version will be checked against the current schema version understood
-      by the IUF.
-
-      Compatibility is defined as follows. Let us refer to the schema version
-      specified by the product manifest file as the "manifest version" and the
-      current schema version used by the IUF as the "current version".
+      The semantic version of the IUF with which this manifest file is expected
+      to be compatible. Version constraints can be specified using ">", ">=",
+      "==", "<", and "<=" comparison operators. Multiple comparison operators
+      can be used to specify a range.
 
 
-      - If the input version has an older major version than the current
-        version, it is incompatible.
+      Version constraints can also be specified with "~" (tilde) and "^" (caret)
+      operators. A full version prefixed with "~" means that all versions with the
+      same major and minor versions are compatible. That is, the patch version
+      is allowed to differ. A full version prefixed with "^" means that all versions
+      with the same major version are compatible. That is, the minor and patch
+      versions are allowed to differ.
 
-      - If the input version has an older minor version than the current
-        version, it may be incompatible, but will be accepted with a warning.
 
-      - If the input version has an older patch version than the current
-        version, it is compatible.
-
-      - If the input version is newer than the current version, it is
-        incompatible because it could contain new fields not understood by the
-        current version.
-
-      - If the input version matches the current version, it is compatible.
-    # TODO: Atif want to see this with a range, e.g. ^1.0.0 or ~1.0.0
-    default: '1.0.0'
+      It is recommended that products specify a caret range matching the
+      current version of the IUF against which the manifest is developed. This
+      will allow the manifest to continue working with new minor and patch
+      versions of the IUF.
     type: string
+    examples:
+    - 1.0.0
+    - ">= 1.0.0 < 2.0"
+    - "< 2.0"
+    - "~1.0.0"
+    - "^1.0.0"
 
   name:
     description: >

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -126,6 +126,10 @@ properties:
   # dependencies, particularly in the install stages responsible for uploading
   # content, deploying services?
   #
+  # Don: CSM-diags is dependent on CPE. This is a functional dependency?
+  # James: COS dependencies are at image build time (operational)
+  # Sarah: SDU has an operational dependency
+  #
   # ===========================================================================
 
 
@@ -213,8 +217,15 @@ properties:
       # We plan to manifestgen all loftsman manifests by default. Is that a problem
       # for any product teams? We can provide an option to disable it.
       #
+      # SMA would pull customizations at run-time and modify it without pushing
+      # it back up and then use it to control size of something in S3.
+      #
       # Do any products provide Loftsman manifests that they don't want to
       # deploy as part of the product_deploy stage? E.g. WLM?
+      #
+      # Slurm has an operator that depends on some CSM multitenancy stuff in
+      # CSM 1.3 so you don't want to deploy unless on CSM 1.3, so it's been
+      # separated out.
       #
       # =======================================================================
       loftsman:
@@ -269,6 +280,8 @@ properties:
       #
       # Do any products currently have more than one "nexus-repositories.yaml"
       # or "nexus-blobstores.yaml" file in their product stream?
+      #
+      # Question from Erik: how do we handle SLE with its multiple tar files?
       #
       # =======================================================================
       nexus_blob_stores:
@@ -434,6 +447,8 @@ properties:
       # =======================================================================
       #
       # Analytics and CPE do this today. Do any other products do this?
+      #
+      # Slingshot fabric manager does this for switch firmware with FAS.
       #
       # =======================================================================
       s3:

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -203,8 +203,8 @@ properties:
           manifest files provided by the product.
 
           Loftsman manifests will be uploaded to S3 storage during the
-          upload_content stage of the install/upgrade. They will be used from
-          this S3 location during the deploy_manifests stage of the install.
+          upload\_content stage of the install/upgrade. They will be used from
+          this S3 location during the deploy\_manifests stage of the install.
 
           If the loftsman manifests are customized with the contents of
           customizations.yaml using manifestgen, then both the pre-customization

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -135,12 +135,8 @@ properties:
           An array of directories containing docker images that should be
           uploaded to the Docker image registry in Nexus at install/upgrade
           time.
-
         default:
         - path: "docker"
-        # TODO: do we want this as opposed to objects.
-        # - "docker"
-
         type: array
         items:
           type: object
@@ -149,9 +145,8 @@ properties:
           properties:
             path:
               description: |
-                The path, relative to the top level of the release distribution
-                directory, containing the container images to be uploaded to the
-                Docker image registry in Nexus.
+                The relative path to a directory containing the container
+                images to be uploaded to the Docker image registry in Nexus.
 
                 The directories contained within the directory specified here
                 must contain container images. The container images will be
@@ -160,29 +155,17 @@ properties:
 
                 For example, if this path contains the following file structure
 
-                arti.hpc.amslabs.hpecorp.net/
-                └── my-container:1.2.4
-                    ├── 007c21b118030b56ce4c303c6ef668f6bdcf2e14f5e63f079b19e1d1883ac7a9
-                    ├── ...
-                    ├── manifest.json
-                    └── version
+                .
+                |-- arti.hpc.amslabs.hpecorp.net
+                    `-- my-container:1.2.4
+                        |-- 1054448d81575250985471206b1c4654b0262d337f1a52ddac9a21208665656e
+                        |-- ...
+                        |-- manifest.json
+                        `-- version
 
-                This container image would be uploaded to the Nexus registry as a
-                arti.hpc.amslabs.hpecorp.net/my-container:1.2.4
+                A single container image would be uploaded to the Nexus Docker
+                registry as arti.hpc.amslabs.hpecorp.net/my-container:1.2.4
               type: string
-
-            # TODO: Do we need the ability to strip components from the path?
-            # Maybe this needs a spike to see how product teams are storing their docker images.
-            # E.g. SAT puts them all under cray/ prefix. COS mixes that approach with using
-            # arti.hpc.../ prefix.
-            # Maybe we don't need to worry about this. Make the product mirror the naming in the nexus
-            # registry with their file structure.
-            strip_leading_components:
-              type: integer
-              default: 0
-              description: >
-                How many leading components of the path should be stripped off when
-                uploading the image to Nexus.
 
       helm:
         description: >

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -321,39 +321,42 @@ properties:
               - raw
               - yum
 
+      # =======================================================================
+      # =============== Question for review session with teams ================
+      # =======================================================================
+      #
+      # Do any products need to provide more than one VCS repo?
+      #
+      # =======================================================================
       vcs:
-        # TODO: Ask product teams if any product provides more than one VCS
-        # repo.
         default: {}
         description: >
-          Information about the VCS repository to be created for this product.
+          Information about the repository to create in VCS (Gitea) for this
+          product.
         type: object
         required:
         - path
         properties:
           path:
             description: >
-              The path, relative to the top level of the product release
-              distribution, to the directory containing the content to upload to
-              a repository in VCS.
+              The relative path to the directory containing the content to
+              upload to a repository in VCS.
             type: string
           import_branch:
             description: >
               The branch name to which the content in the given path should be
-              uploaded in VCS. If this is omitted, the default behavior is to upload
-              to a path of the form cray/${PRODUCT_NAME}/${PRODUCT_VERSION} where
-              PRODUCT_NAME and PRODUCT_VERSION are the name and version of the product,
-              respectively. It is recommended not to change this value unless it is
-              required to do so.
+              uploaded in VCS. If omitted, this will default to
+              cray/PRODUCT_NAME/PRODUCT_VERSION where PRODUCT_NAME and
+              PRODUCT_VERSION are the name and version of the product,
+              respectively. It is recommended not to override this value unless
+              it is absolutely required to do so.
             type: string
-          # The following property is one we want to allow the admin to
-          # override. For Alice, let's not add this property. Let's just worry
-          # about the content upload.
           site_branch:
-            type: string
             description: >
-              The branch name to use as the branch for site customizations.
-              cpe-integration-22.09
+              The branch name to use as the branch for site customizations. If
+              omitted this will default to "integration-PRODUCT_VERSION" where
+              "PRODUCT_VERSION" is the version of the product.
+            type: string
 
       ims:
         description: >

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -1,0 +1,119 @@
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: "Product Manifest for HPE CSM Install-Upgrade Framework (IUF)"
+description: >
+  A manifest that defines the behavior of the IUF when it performs operations
+  against this product.
+# This is the version of the schema itself
+version: 0.1.0
+type: object
+required:
+- schema_version
+- name
+additionalProperties: false
+properties:
+
+  schema_version:
+    description: >
+      The version of the IUF product manifest schema used by this manifest. The
+      version of the schema should be a SemVer-like version number with three
+      components, major.minor.patch. 
+
+      This version will be checked against the current schema version understood
+      by the IUF.
+
+      Compatibility is defined as follows. Let us refer to the schema version
+      specified by the product manifest file as the "manifest version" and the
+      current schema version used by the IUF as the "current version".
+
+
+      - If the input version has an older major version than the current
+        version, it is incompatible.
+
+      - If the input version has an older minor version than the current
+        version, it may be incompatible, but will be accepted with a warning.
+
+      - If the input version has an older patch version than the current
+        version, it is compatible.
+
+      - If the input version is newer than the current version, it is
+        incompatible because it could contain new fields not understood by the
+        current version.
+
+      - If the input version matches the current version, it is compatible.
+    default: '1.0.0'
+    type: string
+
+  name:
+    description: >
+      The name of the product. This product name is the name under which the
+      product will be uploaded to the product catalog.
+    type: string
+    # TODO: Do we want to define a regular expression for allowed product names
+    # pattern: regex in ECMA-262 regular expression dialect goes here
+  
+  version:
+    description: >
+      The version of the product. The format of this version string must conform
+      to the Semantic Versioning 2.0.0 Spec. The version numbers do not need to
+      be assigned and incremented in accordance with the rules and requirements
+      dictated by SemVer, however.
+    type: string
+    # This regex is the official one from the FAQ on semver.org
+    pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+      
+  content:
+    type: object
+    description: >
+      The content delivered by this product, including container images, RPMs,
+      packages repositories, helm charts, loftsman manifests, VCS repositories,
+      IMS images and recipes, and S3 artifacts.
+
+        
+      Note that if the layout of the content is not specified in this manifest,
+      the IUF will assume a default layout as described in the properties here.
+
+    properties:
+      docker:
+        description: >
+          An array of directories containing docker images that should be
+          uploaded to the Docker image registry in Nexus at install/upgrade
+          time.
+
+        type: array
+        items:
+          type: object
+          properties:
+            path:
+              description: |
+                The path, relative to the top level of the release distribution
+                directory, containing the container images to be uploaded to the
+                Docker image registry in Nexus.
+
+                The directories contained within the directory specified here
+                must contain container images. The container images will be
+                uploaded to Nexus with names exactly matching the full path to
+                the directory containing the image manifest.json file.
+
+                For example, if this path contains the following file structure
+                
+                arti.hpc.amslabs.hpecorp.net/
+                └── my-container:1.2.4
+                    ├── 007c21b118030b56ce4c303c6ef668f6bdcf2e14f5e63f079b19e1d1883ac7a9
+                    ├── ...
+                    ├── manifest.json
+                    └── version
+
+                This container image would be uploaded to the Nexus registry as a
+                arti.hpc.amslabs.hpecorp.net/my-container:1.2.4
+              type: string
+
+            # TODO: Do we need the ability to strip components from the path?
+            strip_leading_components:
+              type: integer
+              default: 0
+              description: >
+                How many leading components of the path should be stripped off when
+                uploading the image to Nexus.
+
+  

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -426,8 +426,8 @@ properties:
                 path:
                   description: >
                     The relative path to the directory containing the image
-                    artifacts. The directory should contain a root filesystem
-                    image in the squashfs format, a kernel file, and an initrd.
+                    artifacts. These artifacts may include a root filesystem
+                    image in squashfs format, a kernel file, and an initrd.
 
                     An IMS image record will be created, the image artifacts
                     will be uploaded to the appropriate paths in S3, an IMS
@@ -443,20 +443,17 @@ properties:
                   type: string
                 rootfs_file:
                   description: >
-                    The name of the squashfs file defining the root filesystem for
-                    the image.
+                    The name of the file defining the root filesystem for the
+                    image. This file should be in squashfs format.
                   type: string
-                  default: rootfs
                 kernel_file:
                   description: >
                     The name of the kernel file for the image.
                   type: string
-                  default: kernel
                 initrd_file:
                   description: >
                     The name of the initrd file for the image.
                   type: string
-                  default: initrd
 
       # =======================================================================
       # =============== Question for review session with teams ================

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -1,3 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Schema definition for the IUF Product Manifest
 ---
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Product Manifest for HPE CSM Install-Upgrade Framework (IUF)"

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -247,40 +247,49 @@ properties:
               type: boolean
               default: true
 
-      blobstores_definition:
+      # =======================================================================
+      # =============== Question for review session with teams ================
+      # =======================================================================
+      #
+      # Do any products currently have more than one "nexus-repositories.yaml"
+      # file in their product stream?
+      #
+      # =======================================================================
+      nexus_blob_stores:
         description: >
-          The path to a YAML file that defines the blobstores that should be
-          created for this product. The YAML file should consist of a series
-          documents, each of which defines a blobstore.
+          The Nexus blob stores that should be defined for this product.
+        type: object
+        required:
+        - yaml_path
+        properties:
+          yaml_path:
+            description: >
+              The relative path to a YAML file that defines the Nexus blob
+              stores that should be created for this product. The YAML file
+              should consist of a series of documents, each of which defines a
+              blobstore.
 
-          The schema of each document is unchanged from the Papaya recipe
-          release.
-        type: string
-        # TODO: Do any products define more than one blobstore?
-        # It is possible to do this with a single nexus-blobstores.yaml file
-        # by specifying multiple documents. Check if any products define multiple
-        # blobstores in multiple files (possible SLE)
-        default: nexus-blobstores.yaml
+              The schema of this file is unchanged from the Papaya recipe.
+            type: string
+            default: nexus-blobstores.yaml
 
-      repositories_definition:
+      nexus_repositories:
         description: >
-          The path to a YAML file that defines the Nexus repositories that
-          should be create for this product. The YAML file should consist of a
-          series of documents, each of which defines a Nexus repository.
+          The Nexus repositories that should be defined for this product.
+        type: object
+        required:
+        - yaml_path
+        properties:
+          yaml_path:
+            description: >
+              The relative path to a YAML file that defines the Nexus
+              repositories that should be created for this product. The YAML
+              file should consist of a series of documents, each of which
+              defines a Nexus repository.
 
-          The schema of each document is unchanged from the Papaya recipe
-          release.
-
-          # TODO: Define behavior when repositories defined here already exist in Nexus.
-          # Investigate why Slurm had to delete the old repos. Was it a way to ensure
-          # the type is modified.
-          #
-          # Atif suggests that we must always back up old content if we would
-          # overwrite it. 
-          #
-          # This needs to be discussed further as part of the IUF spec.
-        type: string
-        default: nexus-repositories.yaml
+              The schema of this file is unchanged from the Papaya recipe.
+          type: string
+          default: nexus-repositories.yaml
 
       rpms:
         description: >
@@ -314,46 +323,6 @@ properties:
                 # Decision: For Alice, we won't worry about this. Post-Alice, we
                 # could offer release-generation libraries to simplify across
                 # products.
-
-      # =======================================================================
-      # An alternative way to define Nexus repos under a repositories property
-      # instead of defining them in a separate file referenced by the value of
-      # the "repositories_definition" property.
-      # =======================================================================
-      repositories:
-        description: >
-          An array of package repositories.
-        type: array
-        items:
-          type: object
-          required: name
-          properties:
-            name:
-              description: The name of the repo to create
-              type: string
-            # More properties defining the repo would go here.
-      # =======================================================================
-
-      # =======================================================================
-      # An alternative way to define Nexus blob stores under a blobstores
-      # property instead of defining them in a separate file referenced by the
-      # value of the "blobstores_definition" property.
-      # =======================================================================
-      blobstores:
-        description: >
-          An array of blobstores that should be created in Nexus for this
-          product.
-        type: array
-        items:
-          type: object
-          required:
-          - name
-          properties:
-            name:
-              description: The name of the blobstore to create
-              type: string
-            # More properties defining the blobstore would go here.
-      # =======================================================================
 
       vcs:
         # TODO: Ask product teams if any product provides more than one VCS

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -111,10 +111,6 @@ properties:
 
 
   content:
-    # TODO: Consider whether defaults can/should be specified at this level (in case content property is omitted)
-    default:
-      docker:
-      - path: docker
     type: object
     description: >
       The content delivered by this product, including container images, RPMs,

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -50,37 +50,47 @@ properties:
 
   name:
     description: >
-      The name of the product. This product name is the name under which the
-      product will be uploaded to the product catalog.
+      The abbreviated name of the product. This product name is the name under
+      which the product will be uploaded to the product catalog.
     type: string
-    # TODO: Do we want to define a regular expression for allowed product names
-    # pattern: regex in ECMA-262 regular expression dialect goes here
+    examples:
+    - cos
+    - sat
+    - analytics
+    # TODO: Consider a regular expression for allowed product names
+    # pattern: <regex in ECMA-262 regular expression dialect goes here>
 
   # TODO: Do we want a long name in a description too?
   description:
     description: >
-      A longer name for the product. This is for humans to read and understand.
-      E.g. slingshot-host-software could say what SHS stands for.
+      A description of the product.
     type: string
 
   version:
     description: >
-      The version of the product. The format of this version string must conform
-      to the Semantic Versioning 2.0.0 Spec. The version numbers do not need to
-      be assigned and incremented in accordance with the rules and requirements
-      dictated by SemVer, however.
+      The version of the product. If not specified, the IUF will look for a
+      file named ".version" in the top level of the release distribution
+      directory.  If the version is not specified in the manifest, and there is
+      no ".version" file, an attempt to install the product using the IUF will
+      fail.
 
-      # TODO: Consider whether we want to fall back on the `.version` file that some products
-      # deliver in the release distribution tar file. E.g. Slurm provides one. We don't want
-      # to make the build process more complicated. Or provide a path to the version file. In
-      # this case, we could use a oneOf in the schema.
+      It is recommended that products use a version string format which
+      conforms to the Semantic Versioning 2.0.0 Spec. This does not require
+      that the version numbers be assigned and incremented in accordance with
+      the rules and requirements dictated by SemVer.
 
-      # TODO: Need to look at SLE, CPE, and other products to see if they can fit into SemVer
-      # Note that SemVer is pretty flexible (e.g. should be able to support SLE date strings).
-      # Product like CPE already have to conform to use cray-import-config/cf-gitea-import
+      If the product provides Ansible configuration content which is uploaded to a
+      vcs repository (see the "vcs" property), then the version here must be a
+      valid semantic version.
     type: string
-    # This regex is the official one from the FAQ on semver.org
-    pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+    examples:
+    - 2.4.76
+    - 22.9.4
+    - 1.3.0-rc.3
+    - 2.5.8-20221004160837-9746d6e
+    # If we can enforce that every product uses SemVer, then we can use the
+    # following official regex from the FAQ on semver.org.
+    # pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 
 
   # ===========================================================================

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -4,6 +4,11 @@ title: "Product Manifest for HPE CSM Install-Upgrade Framework (IUF)"
 description: >
   A manifest that defines the behavior of the IUF when it performs operations
   against this product.
+
+
+  This manifest file must be named iuf-product-manifest.yaml in the top level
+  of the product release distribution in order for it to be discovered by the
+  IUF.
 # This is the version of the IUF manifest schema itself
 version: 0.1.0
 type: object
@@ -94,70 +99,35 @@ properties:
 
 
   # ===========================================================================
-  # TODO: Another example of a way to do dependencies where each product can
-  # declare what it provides vs. requires (similar to RPM).
+  # ================= Question for review session with teams ==================
+  # ===========================================================================
   #
-  # Deferred in Alice timeframe
-  # ===========================================================================
-  provides:
-    type: array
-    items:
-      type: string
-      description: TBD. Some sort of string describing what it provides.
-
-  requires:
-    type: array
-    items:
-      type: string
-      description: TBD. Some sort of string describing what it requires.
-  # ===========================================================================
-
-  # ===========================================================================
-  # TODO: One way of specifying dependencies between products would be to have
-  # dependencies at the top level here.
+  # We are not providing a way to declare dependencies for the initial release
+  # of the IUF in Alice. Do any product teams have examples of product install
+  # dependencies, particularly in the install stages responsible for uploading
+  # content, deploying services?
   #
-  # A lot of this is somewhat handled at the HPC CSM Software Recipe manifest
-  # level because this is a set of software that has been validated together.
-  # This doesn't handle one-off install dependency checking.
-  dependencies:
-    description: >
-      The other products on which this product depends. This would be overall
-      dependencies one product has on another, affecting all (?) stages/operations
-      of the product.
-
-      # TODO: Ask product teams about existing dependencies. Atif has not seen
-      # any of these so far. Especially in upload_content. Dean cautions against
-      # doing this at too high of a level because teams will get overly cautious
-      # here and specify dependencies that aren't really needed.
-    type: list
-    items:
-      type: object
-      required:
-      - product_name
-      properties:
-        product_name:
-          description: Name of product on which this one depends.
-          type: string
-        product_version:
-          description: Version of product on which this one depends.
-          type: string
   # ===========================================================================
+
 
   content:
     # TODO: Consider whether defaults can/should be specified at this level (in case content property is omitted)
     default:
       docker:
       - path: docker
-        strip_leading_components: 0
     type: object
     description: >
       The content delivered by this product, including container images, RPMs,
-      packages repositories, helm charts, loftsman manifests, VCS repositories,
+      package repositories, helm charts, loftsman manifests, VCS repositories,
       IMS images and recipes, and S3 artifacts.
 
-
       Note that if the layout of the content is not specified in this manifest,
-      the IUF will assume a default layout as described in the properties here.
+      the IUF will assume a default layout as defined in the property
+      descriptions here.
+
+      Any time a "relative path" is mentioned in the descriptions of properties
+      beneath "content", it means a path relative to the top level of the
+      product release distribution file.
 
     properties:
       docker:

--- a/src/api/models/iuf/iuf-manifest-schema.yaml
+++ b/src/api/models/iuf/iuf-manifest-schema.yaml
@@ -175,9 +175,6 @@ properties:
         type: array
         default:
         - path: helm
-          repository_name: charts
-        # TODO: Consider simplifying this to just a list of strings like "docker" above
-        # - "helm"
         items:
           type: object
           required:
@@ -185,55 +182,43 @@ properties:
           properties:
             path:
               description: >
-                The path, relative to the top level of the release distribution
-                directory, containing the helm charts to be uploaded to a Helm
-                chart repository in Nexus.
+                The relative path to a directory containing the helm charts to
+                be uploaded to a Helm chart repository in Nexus. The directory
+                should contain Helm charts as gzipped tar files. The helm charts
+                will be uploaded to the "charts" Helm chart repository in Nexus.
               type: string
 
-            # TODO: We can probably simplify here for now. Everybody is using "charts".
-            # Putting charts in their own repository for each product is out of scope for IUF.
-            # TODO: Investigate how loftsman knows which Helm repository to use from Nexus
-            # Di says that loftsman needs local copies of the charts instead of going to Nexus.
-            # We confirmed that loftsman uses local copies of charts (e.g. COS). File CASMTRIAGE for loftsman support of remote repos.
-            #
-            # Rob found that loftsman command can use remote chart repos.
-            # Unclear how this works. `--charts-repo` exists, but it is
-            # deprecated in favor of `spec.sources.charts` in the manifests.
-            repository_name:
-              description: >
-                The name of the repository to which the Helm charts should be
-                uploaded in Nexus.
-              type: string
-              default: charts
-
-
+      # =======================================================================
+      # =============== Question for review session with teams ================
+      # =======================================================================
+      #
+      # Will Loftsman manifests need a way to declare dependencies on other
+      # Loftsman manifests, either within a single product or across products?
+      #
+      # Which teams use manifestgen, and which don't?
+      #
+      # Do any products provide Loftsman manifests that they don't want to
+      # deploy as part of the product install and deployment? E.g. WLM?
+      #
+      # =======================================================================
       loftsman:
         description: >
           An array of Loftsman manifest files or directories containing Lofstman
           manifest files provided by the product.
 
+          Loftsman manifests will be uploaded to S3 storage during the
+          upload_content stage of the install/upgrade. They will be used from
+          this S3 location during the deploy_manifests stage of the install.
 
-          # TODO: Discuss with Atif where these manifests should be stored.
-          # Also decide whether we store pre- or post-manifestgen versions.
-          # This ties into the discussion about where we store hooks and any
-          # artifacts needed for any future product install/upgrade/uninstall
-          # operations.
-          # Decision: they will be stored in S3 (pre- and post-manifestgen
-          # versions)
-
-          # TODO: Is there a need to specify dependencies here? Either within a
-          # single product's Loftsman manifests or between products?
-          # Discuss with Atif how dependencies are declared.
+          If the loftsman manifests are customized with the contents of
+          customizations.yaml using manifestgen, then both the pre-customization
+          and post-customization versions of the manifests will be stored in S3.
         type: array
         default:
         - path: manifests
           deploy: true
           manifestgen: true
 
-          # TODO: Example of dependencies
-          # dependencies:
-          # - product: cos
-          #   manifest_path: manifests
         items:
           type: object
           required:
@@ -241,58 +226,24 @@ properties:
           properties:
             path:
               description: >
-                The path to a loftsman manifest file or directory, relative to the top level
-                of the release distribution directory.
+                The relative path to a loftsman manifest file or a directory
+                containing multiple loftsman manifest files.
               type: string
-
-            # TODO: Consider whether dependencies between loftsman manifests are needed here
-            # Jason suggests that perhaps they belong in a separate section.
-            #
-            # Decision: let's not do this for Alice. We can ask product teams
-            # about whether this is required.
-            #
-            # Example schema below
-            dependencies:
-              type: array
-              items:
-                type: object
-                properties:
-                  product:
-                    type: string
-                    description: name of product
-                  manifest_name:
-                    type: string
-                    description: name of manifest provided by product
-            # End of example
 
             use_manifestgen:
               description: >
                 Whether manifestgen needs to be called against the manifest(s).
 
-                manifestgen takes the customizations.yaml file and applies the customizations
-                to the Loftsman manifest file. Customizations to the manifest themselves or to
-                to the values that are passed through to the helm charts.
+                The manifestgen command applies values from customizations.yaml
+                to the Loftsman manifest. These generally affect values in the
+                Loftsman manifest file that are passed through to the Helm
+                charts when they are deployed.
               type: boolean
-              # TODO: Is it more common that products require this or do not require it?
-              # Is it harmless if they do not require it? Should be harmless.
-              #
-              # Atif want to move away from specifying all config values in
-              # customizations.yaml and move towards having these be specified
-              # by the admin either in a file or in a wizard guiding them
-              # through answering required questions as part of starting an IUF
-              # session. We will keep this unchanged for Alice to minimize
-              # impact to product teams and improve in the future.
               default: true
             deploy:
               description: >
                 Whether this loftsman manifest should be deployed as part of the
                 deploy_manifests stage of the IUF.
-
-                # TODO: Reach out to David Gloe to ask for specifics on the WLM use case.
-                # Why would we ever not want to deploy manifests during the deploy_manifests stage?
-                # Atif suggests asking this question at the next meeting with
-                # product teams. Atif hasn't seen any examples where this would
-                # be required. Assume they all need to be deployed.
               type: boolean
               default: true
 


### PR DESCRIPTION
## Summary and Scope

Add a JSON Schema file defining the schema for the IUF Product Manifest file that will be included in each product's release distribution file.

The IUF code in this repo will eventually need to use this IUF Product Manifest schema file to validate the contents of the IUF Product Manifest files provided by each product prior to the `process_media` stage which will then extract the full release distribution. This validation code is not yet written.

The commit history here is copied over from my personal repository on HPE-internal GitHub where I was working on this file for a while. This was done to provide a history of how this file has evolved over the course of our design review sessions on the IUF Adoption Guide and IUF Product Manifest schema.

## Issues and Related PRs

* Resolves [CASM-3531](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3531)
* A validator Docker image will be added as a part of [CASM-3564](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3564)

## Testing

### Tested on:

  * Local development environment

### Test description:

This schema file has been used to validate the COS IUF Product Manifest.

HTML documentation has also been generated manually using the Python package `json-schema-for-humans`.

## Risks and Mitigations

Low risk. Adding a file that's not yet used in any code.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

