### PR TITLE
CASMINST-5735: Update to remove env var for OCI

### DIFF
--- a/.github/workflows/chart_lint_test_scan.yaml
+++ b/.github/workflows/chart_lint_test_scan.yaml
@@ -5,8 +5,6 @@ on:
       - master
       - release/**
   workflow_dispatch:
-env:
-  HELM_EXPERIMENTAL_OCI: 1
 jobs:
   lint-test-scan:
     uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/charts_lint_test_scan.yaml@v2

--- a/charts/v1.0/cray-iuf/values.yaml
+++ b/charts/v1.0/cray-iuf/values.yaml
@@ -21,6 +21,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+global:
+  appVersion: 0.0.1
 metacontroller-helm:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/metacontrollerio/metacontroller

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,7 +1,6 @@
 ---
 chart-dirs: []
-chart-repos:
-  - cray-algol60=https://artifactory.algol60.net/artifactory/csm-helm-charts
+chart-repos: []
 validate-maintainers: false
 check-version-increment: false
 target-branch: master


### PR DESCRIPTION
## Summary and Scope

HMS Github workflows now support OCI registries by default, so we don't need to specify the env var for it, which is breaking the linter action currently.
