### PR TITLE
CASMINST-5783: create service for argo-workflows-workflow-controller

### DIFF
--- a/charts/v1.0/cray-nls/templates/service.yaml
+++ b/charts/v1.0/cray-nls/templates/service.yaml
@@ -38,27 +38,27 @@ spec:
   selector:
     app.kubernetes.io/instance: cray-nls
     app.kubernetes.io/name: argo-workflows-server
-#---
-#apiVersion: v1
-#kind: Service
-#metadata:
-#  name: workflow-controller-metrics
-#  annotations:
-#    meta.helm.sh/release-name: argo-only
-#  labels:
-#    app.kubernetes.io/component: workflow-controller
-#    app.kubernetes.io/instance: argo-only
-#    app.kubernetes.io/managed-by: Helm
-#    app.kubernetes.io/name: argo-workflows-workflow-controller
-#    app.kubernetes.io/part-of: argo-workflows
-#spec:
-#  ports:
-#  - name: metrics
-#    port: 8080
-#    protocol: TCP
-#    targetPort: 9090
-#  selector:
-#    app.kubernetes.io/instance: argo-only
-#    app.kubernetes.io/name: argo-workflows-workflow-controller
-#  sessionAffinity: None
-#  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflow-controller-metrics
+  annotations:
+    meta.helm.sh/release-name: cray-nls
+  labels:
+    app.kubernetes.io/component: workflow-controller
+    app.kubernetes.io/instance: cray-nls
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/part-of: argo-workflows
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app.kubernetes.io/instance: cray-nls
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
Summary and Scope
[CASMINST-5783] : currently there is no service for argo-workflows-workflow-controller which requires to scrape Prometheus metrics from Argo workflow controller

Issues and Related PRs
create service for argo-workflows-workflow-controller

Resolves [issue id](issue link)
Change will also be needed in <insert branch name here>
Future work required by [issue id](issue link)
Documentation changes required in [issue id](issue link)
Merge with/before/after <insert PR URL here>
Testing
List the environments in which these changes were tested.

Tested on: frigg
firgg

Test description:
kubectl get svc -n argo |grep workflow-controller
cray-nls-argo-workflows-workflow-controller ClusterIP 10.16.226.7 8080/TCP 36d
workflow-controller-metrics ClusterIP 10.17.97.171 8080/TCP 36d
ncn-m001:/opt/cray/iuf/rambabu # kubectl get ep -n argo |grep workflow-controller
cray-nls-argo-workflows-workflow-controller 10.40.0.50:9090,10.43.0.244:9090 36d
workflow-controller-metrics 36d