### PR TITLE
CASM-4557 iuf-backend changes for getting m001 upgrade workflow

### DIFF
--- a/src/api/services/iuf/sessions_workflow_gen.go
+++ b/src/api/services/iuf/sessions_workflow_gen.go
@@ -672,14 +672,23 @@ func (s iufService) getDAGTasksForGlobalStage(session iuf.Session, stageInfo iuf
 // Get the master, worker, or storage workflow for management nodes rollout operation
 func (s iufService) getManagementNodesRolloutSubOperation(limitManagementNodes []string) (string, error) {
 	validator := utils.NewValidator()
-	workFlowType, err := validator.ValidateLimitManagementNodesInput(limitManagementNodes)
+	var workflowType string
+	workflowType, err := validator.ValidateLimitManagementNodesInput(limitManagementNodes)
 	if err != nil {
 		return "", err
 	}
 	workflowNames := map[string]string{
 		"worker":	"management-worker-nodes-rollout",
 		"storage":	"management-storage-nodes-rollout",
-		"master":	"management-two-master-nodes-rollout",
+		"master1":	"management-m001-rollout",
+		"masterOther":	"management-two-master-nodes-rollout",
 	}
-	return workflowNames[workFlowType], nil
+	if workflowType == "master" {
+		if limitManagementNodes[0] == "ncn-m001" {
+			workflowType = "master1"
+		} else {
+			workflowType = "masterOther"
+		}
+	}
+	return workflowNames[workflowType], nil
 }


### PR DESCRIPTION
## Summary and Scope

As part of the effort to upgrade CSM 'as a product', the ncn-m001 upgrade was automate. This changes the IUF backend to be able to get the ncn-m001 upgrade workflow if ncn-m001 is supplied as an argument to --limit-management-rollout.

## Issues and Related PRs

* Resolves [CASM-4557](https://jira-pro.it.hpe.com:8443/browse/CASM-4557)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Mug - CSM 1.5

### Test description:

I tested the new cray-nls docker image with the existing cray-nls deployment on the system. I saw that using the iuf-cli, the backend would correctly get the ncn-m001 or ncn-m002/3 workflow based on the argument provided to '--limit-management-rollout'.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

