### PR TITLE
CASMINST-6832 IUF prepare-images stage should not clear image metadata

### DIFF
--- a/src/api/services/iuf/sessions.go
+++ b/src/api/services/iuf/sessions.go
@@ -549,6 +549,9 @@ func (s iufService) ProcessOutput(session *iuf.Session, workflow *v1alpha1.Workf
 					len(nodeStatus.Outputs.Parameters) > 0 {
 					operationName := nodeStatus.TemplateScope[len("namespaced/"):len(nodeStatus.TemplateScope)]
 					stepName := nodeStatus.DisplayName
+					if nodeStatus.Outputs.Parameters[0].Value.String() == "" {
+						continue
+					}
 					s.logger.Infof("process output for Activity %s, Operation %s, step %s with value %v", activity.Name, operationName, stepName, nodeStatus.Outputs)
 					stepChanged, err := s.updateActivityOperationOutputFromWorkflow(&activity, session, &nodeStatus, operationName, stepName, "")
 					if err != nil {


### PR DESCRIPTION
## Summary and Scope

This is a bug fix which will prevent the overwriting of the metadata of the prepare-images stage.

## Issues and Related PRs

* Resolves [CASMINST-6832](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6832)

### Tested on:

  * starlord

### Test description:

First , managed images were built. 
In the second run using the same activity only management images were built. 
The second run did not overwrite the managed images which were prepared in the first run

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

