### PR TITLE
CAMSINST-7104: adding two input params

### DIFF
--- a/docs/IUF_swagger.yaml
+++ b/docs/IUF_swagger.yaml
@@ -140,6 +140,9 @@ definitions:
     type: object
   iuf.InputParameters:
     properties:
+      boot_image_management:
+        description: The IMS image ID to be used for booting management nodes
+        type: string
       bootprep_config_managed:
         description: The path to the bootprep config file for managed nodes, relative
           to the media_dir
@@ -147,6 +150,9 @@ definitions:
       bootprep_config_management:
         description: The path to the bootprep config file for management nodes, relative
           to the media_dir
+        type: string
+      cfs_configuration_management:
+        description: The cfs configuration name to be used for booting management nodes
         type: string
       concurrency:
         description: An integer defining how many products / operations can we concurrently

--- a/src/api/models/iuf/shared.go
+++ b/src/api/models/iuf/shared.go
@@ -44,6 +44,8 @@ type InputParameters struct {
 	Concurrency                           int64                   `json:"concurrency"`                                   // An integer defining how many products / operations can we concurrently execute.
 	BootprepConfigManaged                 string                  `json:"bootprep_config_managed"`                       // The path to the bootprep config file for managed nodes, relative to the media_dir
 	BootprepConfigManagement              string                  `json:"bootprep_config_management"`                    // The path to the bootprep config file for management nodes, relative to the media_dir
+	CfsConfigurationManagement            string                  `json:"cfs_configuration_management"`                  // The name of the cfs configuration for management nodes
+	BootImageManagement                   string                  `json:"boot_image_management"`                         // The name of the boot image to be used for management nodes
 	Stages                                []string                `json:"stages"`                                        // Stages to execute
 	Force                                 bool                    `json:"force"`                                         // Force re-execution of stage operations
 } //	@name	InputParameters
@@ -59,6 +61,8 @@ type InputParametersPatch struct {
 	Concurrency                           *int64                   `json:"concurrency"`                                   // An integer defining how many products / operations can we concurrently execute.
 	BootprepConfigManaged                 *string                  `json:"bootprep_config_managed"`                       // The path to the bootprep config file for managed nodes, relative to the media_dir
 	BootprepConfigManagement              *string                  `json:"bootprep_config_management"`                    // The path to the bootprep config file for management nodes, relative to the media_dir
+	CfsConfigurationManagement            *string                  `json:"cfs_configuration_management"`                  // The name of the cfs configuration for management nodes
+	BootImageManagement                   *string                  `json:"boot_image_management"`                         // The name of the boot image to be used for management nodes
 	Stages                                *[]string                `json:"stages"`                                        // Stages to execute
 	Force                                 *bool                    `json:"force"`                                         // Force re-execution of stage operations
 } //	@name	InputParameters

--- a/src/api/services/iuf/activities.go
+++ b/src/api/services/iuf/activities.go
@@ -33,7 +33,6 @@ import (
 	"github.com/Cray-HPE/cray-nls/src/utils"
 	"sort"
 	"time"
-
 	iuf "github.com/Cray-HPE/cray-nls/src/api/models/iuf"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -171,6 +170,14 @@ func (s iufService) PatchActivity(activity iuf.Activity, patchParams iuf.PatchAc
 	}
 	if patchParams.InputParameters.Force != nil {
 		activity.InputParameters.Force = *(patchParams.InputParameters.Force)
+	}
+
+	// Add new parameters
+	if patchParams.InputParameters.CfsConfigurationManagement != nil {
+		activity.InputParameters.CfsConfigurationManagement = *(patchParams.InputParameters.CfsConfigurationManagement)
+	}
+	if patchParams.InputParameters.BootImageManagement != nil {
+		activity.InputParameters.BootImageManagement = *(patchParams.InputParameters.BootImageManagement)
 	}
 
 	// patch site parameters...all or nothing for Products and Global attributes

--- a/src/api/services/iuf/sessions_global_params.go
+++ b/src/api/services/iuf/sessions_global_params.go
@@ -114,6 +114,8 @@ func (s iufService) getGlobalParamsInputParams(session iuf.Session, in_product i
 		"concurrent_management_rollout_percentage": session.InputParameters.ConcurrentManagementRolloutPercentage,
 		"media_host":                               session.InputParameters.MediaHost,
 		"concurrency":                              session.InputParameters.Concurrency,
+		"cfs_configuration_management":             session.InputParameters.CfsConfigurationManagement,
+		"boot_image_management":                    session.InputParameters.BootImageManagement,
 	}
 }
 

--- a/src/api/services/iuf/sessions_test.go
+++ b/src/api/services/iuf/sessions_test.go
@@ -26,6 +26,9 @@ package services_iuf
 
 import (
 	"encoding/json"
+	"regexp"
+	"testing"
+
 	mocks "github.com/Cray-HPE/cray-nls/src/api/mocks/services"
 	iuf "github.com/Cray-HPE/cray-nls/src/api/models/iuf"
 	"github.com/Cray-HPE/cray-nls/src/utils"
@@ -40,8 +43,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fake "k8s.io/client-go/kubernetes/fake"
-	"regexp"
-	"testing"
 )
 
 func TestCreateIufWorkflow(t *testing.T) {
@@ -580,6 +581,8 @@ func TestProcessOutput(t *testing.T) {
 												  "contents": "boot prep file contents as a string"
 												}
 											  ],
+											  "cfs_configuration_management": "test-config",
+											  "boot_image_management": "test-image",
 											  "limit_management_nodes": ["x12413515", "x15464574"]
 											},
 											"site_params": {
@@ -730,6 +733,8 @@ func TestProcessOutput(t *testing.T) {
 												  "contents": "boot prep file contents as a string"
 												}
 											  ],
+											  "cfs_configuration_management": "test-config",
+											  "boot_image_management": "test-image",
 											  "limit_management_nodes": ["x12413515", "x15464574"]
 											},
 											"site_params": {
@@ -888,6 +893,8 @@ func TestProcessOutput(t *testing.T) {
 												  "contents": "boot prep file contents as a string"
 												}
 											  ],
+											  "cfs_configuration_management": "test-config",
+											  "boot_image_management": "test-image",
 											  "limit_management_nodes": ["x12413515", "x15464574"]
 											},
 											"site_params": {
@@ -1047,6 +1054,8 @@ func TestProcessOutput(t *testing.T) {
 												  "contents": "boot prep file contents as a string"
 												}
 											  ],
+											  "cfs_configuration_management": "test-config",
+											  "boot_image_management": "test-image",
 											  "limit_management_nodes": ["x12413515", "x15464574"]
 											},
 											"site_params": {


### PR DESCRIPTION
## Summary and Scope

Adding two input parameters- **_"boot_image_management"_** and **_"cfs_configuration_management"_** to be used in management nodes rollout stage for the rebuild.

## Issues and Related PRs

* Resolves [CASMINST-7104](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7104)
* https://github.com/Cray-HPE/iuf-cli/pull/190


## Testing

Tested without rebuilding the nodes. Needs to be tested with rebuild once cluster is available

### Tested on:

  * `<development system>`


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

