### PR TITLE
CASMTRIAGE-8345: skip management-nodes-rollout prehook in reboot

### DIFF
--- a/src/api/services/iuf/sessions_hooks.go
+++ b/src/api/services/iuf/sessions_hooks.go
@@ -51,6 +51,10 @@ func (s iufService) getProductHookTasks(session iuf.Session, stage iuf.Stage, st
 		return preSteps, postSteps
 	}
 
+	if stage.Name == "management-nodes-rollout" && session.InputParameters.ManagementRolloutStrategy == iuf.EManagementRolloutStrategyReboot {
+		return preSteps, postSteps
+	}
+
 	hooks := s.getProductHooks(session, stage)
 
 	preSteps = map[string]v1alpha1.DAGTask{}


### PR DESCRIPTION
## Summary and Scope

In case of reboot, the pre-hook for management-nodes-rollout should not run.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8345](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8345)

## Testing

ran reboot of w003

### Tested on:

  * wasp

## Risks and Mitigations

No unknown issue


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

